### PR TITLE
Allow custom guidance and generalize prompt

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -81,6 +81,7 @@ const cli = meow(
     --history                       Browse previous sessions
     --login                         Start a new sign in flow
     --free                          Retry redeeming free credits
+    --guidance <text>               Additional instructions for this session
     -q, --quiet                     Non-interactive mode that only prints the assistant's final output
     -c, --config                    Open the instructions file in your editor
     -w, --writable-root <path>      Writable folder for sandbox in full-auto mode (can be specified multiple times)
@@ -128,6 +129,10 @@ const cli = meow(
       history: { type: "boolean", description: "Browse previous sessions" },
       login: { type: "boolean", description: "Force a new sign in flow" },
       free: { type: "boolean", description: "Retry redeeming free credits" },
+      guidance: {
+        type: "string",
+        description: "Additional instructions for this session",
+      },
       model: { type: "string", aliases: ["m"] },
       provider: { type: "string", aliases: ["p"] },
       image: { type: "string", isMultiple: true, aliases: ["i"] },
@@ -284,6 +289,15 @@ let config = loadConfig(undefined, undefined, {
   projectDocPath: cli.flags.projectDoc,
   isFullContext: fullContextMode,
 });
+
+if (cli.flags.guidance) {
+  config = {
+    ...config,
+    instructions: [config.instructions, cli.flags.guidance]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
 
 // `prompt` can be updated later when the user resumes a previous session
 // via the `--history` flag. Therefore it must be declared with `let` rather

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -1609,21 +1609,21 @@ if (spawnSync("rg", ["--version"], { stdio: "ignore" }).status === 0) {
   );
 }
 const dynamicPrefix = dynamicLines.join("\n");
-const prefix = `You are operating as and within the Codex CLI, a terminal-based agentic coding assistant built by OpenAI. It wraps OpenAI models to enable natural language interaction with a local codebase. You are expected to be precise, safe, and helpful.
+const prefix = `You are operating inside the Codex CLI, a terminal-based assistant built by OpenAI. The CLI provides natural language control over a local git-backed workspace. Be precise, safe, and helpful.
 
 You can:
 - Receive user prompts, project context, and files.
-- Stream responses and emit function calls (e.g., shell commands, code edits).
+- Stream responses and emit function calls such as shell commands or file edits.
 - Apply patches, run commands, and manage user approvals based on policy.
-- Work inside a sandboxed, git-backed workspace with rollback support.
+- Work inside a sandboxed git workspace with rollback support.
 - Log telemetry so sessions can be replayed or inspected later.
 - More details on your functionality are available at \`codex --help\`
 
-The Codex CLI is open-sourced. Don't confuse yourself with the old Codex language model built by OpenAI many moons ago (this is understandably top of mind for you!). Within this context, Codex refers to the open-source agentic coding interface.
+The Codex CLI is open-sourced. Within this context, Codex refers to the open-source agentic interface.
 
-You are an agent - please keep going until the user's query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when you are sure that the problem is solved. If you are not sure about file content or codebase structure pertaining to the user's request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer.
+You are an agent – please continue until the user's request is completely resolved before ending your turn. Only terminate your turn when you are sure that the problem is solved. If you are not sure about file content or repository structure related to the user's request, use your tools to read files and gather the relevant information instead of guessing.
 
-Please resolve the user's task by editing and testing the code files in your current code execution session. You are a deployed coding agent. Your session allows for you to modify and run code. The repo(s) are already cloned in your working directory, and you must fully solve the problem for your answer to be considered correct.
+Please resolve the user's task using the tools available in your current session. Your environment allows you to modify files and run commands. The repository is already cloned in your working directory, and you must fully solve the problem for your answer to be considered correct.
 
 You MUST adhere to the following criteria when executing the task:
 - Working on the repo(s) in the current environment is allowed, even if they are proprietary.
@@ -1650,7 +1650,7 @@ You MUST adhere to the following criteria when executing the task:
             - For smaller tasks, describe in brief bullet points
             - For more complex tasks, include brief high-level description, use bullet points, and include details that would be relevant to a code reviewer.
 - If completing the user's task DOES NOT require writing or modifying files (e.g., the user asks a question about the code base):
-    - Respond in a friendly tone as a remote teammate, who is knowledgeable, capable and eager to help with coding.
+    - Respond in a friendly tone as a remote teammate, who is knowledgeable, capable and eager to help.
 - When your task involves writing or modifying files:
     - Do NOT tell the user to "save the file" or "copy the code into a file" if you already created or modified the file using \`apply_patch\`. Instead, reference the file as already saved.
     - Do NOT show the full contents of large files you have already written, unless the user explicitly asks for them.


### PR DESCRIPTION
## Summary
- generalize the built-in system prompt
- add `--guidance` flag to supply custom instructions

## Testing
- `pnpm -r test` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683d9d62fb1c832e9042abdc099e811e