### PR TITLE
Add Firecrawl search tools

### DIFF
--- a/codex-cli/src/utils/firecrawl/client.ts
+++ b/codex-cli/src/utils/firecrawl/client.ts
@@ -1,0 +1,32 @@
+export type SearchResult = { title: string; url: string; description: string };
+
+const API_BASE = 'https://api.firecrawl.dev/v1';
+const API_KEY = process.env['FIRECRAWL_API_KEY'] || '';
+
+async function firecrawlRequest(endpoint: string, body: unknown) {
+  if (!API_KEY) {
+    throw new Error('FIRECRAWL_API_KEY is not set');
+  }
+  const res = await fetch(`${API_BASE}/${endpoint}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`Firecrawl request failed with status ${res.status}`);
+  }
+  return (await res.json()) as any;
+}
+
+export async function searchWeb(query: string, limit = 5): Promise<Array<SearchResult>> {
+  const data = await firecrawlRequest('search', { query, limit });
+  return data.data as Array<SearchResult>;
+}
+
+export async function getUrlContent(url: string): Promise<string> {
+  const data = await firecrawlRequest('scrape', { url, formats: ['markdown'] });
+  return data.data?.markdown || '';
+}


### PR DESCRIPTION
## Summary
- integrate Firecrawl API helper
- expose `web_search` and `get_url` tools to the agent loop
- update usage instructions about internet access

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6842fafe8c84832e9256401508d26281