### PR TITLE
Remove platform sandboxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,16 +182,9 @@ we're confident in additional safeguards.
 
 ### Platform sandboxing details
 
-The hardening mechanism Conseil uses depends on your OS:
-
-- **macOS 12+** - commands are wrapped with **Apple Seatbelt** (`sandbox-exec`).
-
-  - Everything is placed in a read-only jail except for a small set of
-    writable roots (`$PWD`, `$TMPDIR`, `~/.conseil`, etc.).
-  - Outbound network is allowed by default.
-
-- **Linux** - there is no sandboxing by default. This distribution assumes Codex
-  already runs inside a container, so no additional Docker wrapper is required.
+Conseil now always runs inside its own container. Because of this the CLI no
+longer relies on macOS Seatbelt or Linux Landlock. All commands execute directly
+within the container environment.
 
 ---
 
@@ -304,9 +297,6 @@ corepack enable
 # Install dependencies and build
 pnpm install
 pnpm build
-
-# Linux-only: download prebuilt sandboxing binaries (requires gh and zstd).
-./scripts/install_native_deps.sh
 
 # Get the usage and the options
 node ./dist/cli.js --help
@@ -652,7 +642,7 @@ helper script in `conseil-cli/scripts/` does all the heavy lifting. Inside the
 `conseil-cli` folder run:
 
 ```bash
-# Classic, JS implementation that includes small, native binaries for Linux sandboxing.
+# Classic JS implementation.
 pnpm stage-release
 
 # Optionally specify the temp directory to reuse between runs.

--- a/codex-cli/src/utils/agent/exec.ts
+++ b/codex-cli/src/utils/agent/exec.ts
@@ -5,13 +5,10 @@ import type { ParseEntry } from "shell-quote";
 
 import { process_patch } from "./apply-patch.js";
 import { SandboxType } from "./sandbox/interface.js";
-import { execWithLandlock } from "./sandbox/landlock.js";
-import { execWithSeatbelt } from "./sandbox/macos-seatbelt.js";
 import { exec as rawExec } from "./sandbox/raw-exec.js";
 import { formatCommandForDisplay } from "../../format-command.js";
 import { log } from "../logger/log.js";
 import fs from "fs";
-import os from "os";
 import path from "path";
 import { parse } from "shell-quote";
 import { resolvePathAgainstWorkdir } from "src/approvals.js";
@@ -54,27 +51,9 @@ export function exec(
   };
 
   switch (sandbox) {
-    case SandboxType.NONE: {
-      // SandboxType.NONE uses the raw exec implementation.
+    case SandboxType.NONE:
+    default: {
       return rawExec(cmd, opts, config, abortSignal);
-    }
-    case SandboxType.MACOS_SEATBELT: {
-      // Merge default writable roots with any user-specified ones.
-      const writableRoots = [
-        process.cwd(),
-        os.tmpdir(),
-        ...additionalWritableRoots,
-      ];
-      return execWithSeatbelt(cmd, opts, writableRoots, config, abortSignal);
-    }
-    case SandboxType.LINUX_LANDLOCK: {
-      return execWithLandlock(
-        cmd,
-        opts,
-        additionalWritableRoots,
-        config,
-        abortSignal,
-      );
     }
   }
 }

--- a/codex-cli/src/utils/agent/sandbox/interface.ts
+++ b/codex-cli/src/utils/agent/sandbox/interface.ts
@@ -1,7 +1,5 @@
 export enum SandboxType {
   NONE = "none",
-  MACOS_SEATBELT = "macos.seatbelt",
-  LINUX_LANDLOCK = "linux.landlock",
 }
 
 export type ExecInput = {


### PR DESCRIPTION
## Summary
- remove Seatbelt and Landlock sandbox code paths
- update sandbox selection logic
- remove mention of native sandbox binaries from docs

## Testing
- `pnpm --filter @openai/conseil run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684402ac7f90832ebada7a47af57318c