### PR TITLE
Add tmux management tools and setup script

### DIFF
--- a/codex-cli/src/utils/agent/tmux.ts
+++ b/codex-cli/src/utils/agent/tmux.ts
@@ -1,0 +1,38 @@
+import type { AppConfig } from "../config.js";
+import { exec } from "./exec.js";
+import { SandboxType } from "./sandbox/interface.js";
+
+export type TmuxResult = { output: string; metadata: { exit_code: number; duration_seconds: number } };
+
+async function runTmux(
+  cmd: Array<string>,
+  config: AppConfig,
+): Promise<TmuxResult> {
+  const start = Date.now();
+  const { stdout, stderr, exitCode } = await exec(
+    { cmd, workdir: undefined, timeoutInMillis: undefined, additionalWritableRoots: [] },
+    SandboxType.NONE,
+    config,
+  );
+  const duration = Date.now() - start;
+  return {
+    output: stdout || stderr,
+    metadata: { exit_code: exitCode, duration_seconds: Math.round(duration / 100) / 10 },
+  };
+}
+
+export function tmuxCreate(session: string, config: AppConfig): Promise<TmuxResult> {
+  return runTmux(["tmux", "new-session", "-d", "-s", session], config);
+}
+
+export function tmuxDelete(session: string, config: AppConfig): Promise<TmuxResult> {
+  return runTmux(["tmux", "kill-session", "-t", session], config);
+}
+
+export function tmuxOutput(session: string, config: AppConfig): Promise<TmuxResult> {
+  return runTmux(["tmux", "capture-pane", "-p", "-t", session], config);
+}
+
+export function tmuxSend(session: string, command: string, config: AppConfig): Promise<TmuxResult> {
+  return runTmux(["tmux", "send-keys", "-t", session, command, "C-m"], config);
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap development environment for the Codex monorepo.
+# This script installs all Node.js dependencies using pnpm.
+
+# Ensure corepack is available and enable it to manage pnpm versions.
+command -v corepack >/dev/null 2>&1 || {
+  echo "corepack is required but not installed." >&2
+  exit 1
+}
+corepack enable
+
+# Install workspace dependencies.
+pnpm install
+


### PR DESCRIPTION
## Summary
- expose tmux management helpers in the agent loop
- provide tmux helper module with wrapper around tmux commands
- add a setup.sh script to install dependencies

## Testing
- `pnpm --filter @openai/conseil run test` *(fails: vitest not found)*
- `pnpm --filter @openai/conseil run lint` *(fails: ESLint config missing)*


------
https://chatgpt.com/codex/tasks/task_e_6843f78987b0832ea885e632d26da887